### PR TITLE
問題解決：サイドバーの下線

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -50,6 +50,9 @@
     background-color: #2f3e51;
     padding: 0 20px;
     overflow: scroll;
+    #group-list{
+      text-decoration: none;
+    }
     &__display{
       padding: 20px 0 40px 0;
       font-size:0;

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -12,7 +12,7 @@
             = icon('fa','cog')
   .side_bar__group-list
     - current_user.groups.each do |group|  
-      =link_to group_messages_path(group) do
+      =link_to group_messages_path(group),id: "group-list" do
         %ul.side_bar__group-list__display
           %li.side_bar__group-list__display__name
             = group.name


### PR DESCRIPTION
# WHAT
sidebarのグループ名とメッセージを纏めてボタン化しているaタブ（link_to）にidを付与
# WHY
sidebarのグループ名とメッセージ部分の下線が消えていないことのご指摘を頂いた為